### PR TITLE
chore(add-warn): add a warning to add anywhere but the end of the array

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -2513,6 +2513,8 @@ const pages = [
       'Wordpress',
     ],
   },
+  // 🚨 DO NOT ADD YOURSELF TO THE END OF THE ARRAY 🚨
+  // IT CAUSES MERGE CONFLICT HEADACHES
 ];
 
 export default pages;


### PR DESCRIPTION
After solving my share of merge conflicts, it seems if people add themselves somewhere between 2 other people it can be merged with less issues than everyone appending to the array.