### PR TITLE
Remove the first letter(@) from the twitter url

### DIFF
--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -60,7 +60,7 @@ export default function Person({ person, currentTag }) {
         {person.twitter && (
           <TwitterHandle>
             <a
-              href={`https://twitter.com/${person.twitter}`}
+              href={`https://twitter.com/${person.twitter.replace('@', '')}`}
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
Removing the first letter(@) from the twitter url, because it doesn't work on Android devices with the Twitter app.

Example:
From `https://twitter.com/@cristianbgp` to `https://twitter.com/cristianbgp`