### PR TITLE
chore: downgrade scripts support to node 12

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     title: `/uses`,
     description: `A list of /uses pages detailing developer setups.`,
     author: `@wesbos`,
-    siteUrl: "https://uses.tech",
+    siteUrl: 'https://uses.tech',
   },
   plugins: [
     {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "description": "What do you uses",
   "version": "7.7.7",
   "author": "Wes Bos",
-  "type": "module",
   "eslintConfig": {
     "extends": [
       "wesbos"
     ]
+  },
+  "engines": {
+    "node": ">= 12"
   },
   "dependencies": {
     "@actions/core": "^1.2.1",

--- a/scripts/data-validate.js
+++ b/scripts/data-validate.js
@@ -1,6 +1,6 @@
-import core from '@actions/core';
-import { getMasterData, Schema, getStatusCode } from './utils.js';
-import srcData from '../src/data.js';
+const core = require('@actions/core');
+const { getMasterData, Schema, getStatusCode } = require('./utils.js');
+const srcData = require('../src/data.js');
 
 (async () => {
   // on master branch will be empty array
@@ -19,7 +19,7 @@ import srcData from '../src/data.js';
   });
 
   let failedUrlsCount = 0;
-  for await (const { url } of data) {
+  for (const { url } of data) {
     try {
       const statusCode = await getStatusCode(url);
       if (statusCode < 200 || statusCode >= 400) {

--- a/scripts/flags.js
+++ b/scripts/flags.js
@@ -1,4 +1,4 @@
-const flags = [
+module.exports = [
   '🇦🇫',
   '🇦🇱',
   '🇩🇿',
@@ -236,5 +236,3 @@ const flags = [
   '🏳️‍🌈',
   '🇪🇺',
 ];
-
-export default flags;

--- a/scripts/masterData.js
+++ b/scripts/masterData.js
@@ -2,4 +2,4 @@
  * this is a stub file, do not edit it
  * see `scripts/utils.js` -> `getMasterData`
  */
-export default [];
+module.exports = [];

--- a/scripts/populate-readme.js
+++ b/scripts/populate-readme.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import data from '../src/data.js';
+const fs = require('fs');
+const data = require('../src/data.js');
 
 /** @type {string} */
 const readmeTemplate = fs.readFileSync('./scripts/readme-template.md', 'utf8');

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,9 +1,9 @@
-import exec from '@actions/exec';
-import core from '@actions/core';
-import Joi from '@hapi/joi';
-import * as http from 'http';
-import * as https from 'https';
-import flags from './flags.js';
+const exec = require('@actions/exec');
+const core = require('@actions/core');
+const Joi = require('@hapi/joi');
+const http = require('http');
+const https = require('https');
+const flags = require('./flags.js');
 
 async function getCurrentBranchName() {
   let myOutput = '';
@@ -22,7 +22,7 @@ async function getCurrentBranchName() {
 }
 
 /** on master branch will return an empty array */
-export async function getMasterData() {
+module.exports.getMasterData = async function() {
   const options = { silent: true };
   const curentBranchName = await getCurrentBranchName();
   // when on a branch/PR different from master
@@ -38,7 +38,8 @@ export async function getMasterData() {
     core.info('Executing action on master branch');
   }
 
-  const masterData = await import('./masterData.js').then(m => m.default);
+  // eslint-disable-next-line global-require
+  const masterData = require('./masterData.js');
 
   // restore `scripts/masterData.js` after was loaded
   if (curentBranchName !== 'master') {
@@ -46,9 +47,9 @@ export async function getMasterData() {
   }
 
   return masterData;
-}
+};
 
-export const Schema = Joi.object({
+module.exports.Schema = Joi.object({
   name: Joi.string().required(),
   description: Joi.string().required(),
   url: Joi.string()
@@ -65,7 +66,7 @@ export const Schema = Joi.object({
   tags: Joi.array().items(Joi.string()),
 });
 
-export function getStatusCode(url) {
+module.exports.getStatusCode = function(url) {
   const client = url.startsWith('https') ? https : http;
   return new Promise((resolve, reject) => {
     const REQUEST_TIMEOUT = 10000;
@@ -82,4 +83,4 @@ export function getStatusCode(url) {
       })
       .on('error', err => reject(err));
   });
-}
+};

--- a/src/data.js
+++ b/src/data.js
@@ -1,4 +1,5 @@
-export default [
+// keep it commonjs export
+module.exports = [
   {
     name: 'Wes Bos',
     description:


### PR DESCRIPTION
From start scripts needed to be run with node 13 (esm support)
Because data.js was a esm export, and needed to be compiled
Moved all scripts to commontjs, and data.js file
So can be imported by scripts without compiling