### PR TITLE
add scroll to top compatibility with other browsers

### DIFF
--- a/src/components/BackToTop.js
+++ b/src/components/BackToTop.js
@@ -24,6 +24,14 @@ const BackToTopLink = styled.a`
   }
 `;
 
+function scrollTopMax() {
+  let ref;
+  // scrollTopMax is only on Firefox right now! https://caniuse.com/#search=scrolltopmax
+  return (ref = document.scrollingElement.scrollTopMax) != null
+    ? ref
+    : document.scrollingElement.scrollHeight - document.documentElement.clientHeight
+}
+
 function useScrollPosition() {
   const [percent, setPercent] = useState(0);
 
@@ -31,7 +39,7 @@ function useScrollPosition() {
     console.log(document.documentElement.scrollTop);
     const howFar =
       document.documentElement.scrollTop /
-      document.documentElement.scrollTopMax;
+      scrollTopMax();
     setPercent(howFar);
   }
 


### PR DESCRIPTION
<!--

## Final Requirements

* You've read and understood the above

**Add your name to verify:** Mina

-->

Hey man, just noticed the scroll to top doesn't show on other browsers besides Firefox. I gotta love listening to SyntaxFM so I know you were only using Firefox for a month straight.

I really like this site, I just figured to contribute. Thank you!

I found the function scrollTopMax here - https://stackoverflow.com/a/36368796
