### PR TITLE
Fix  Unavatar Twitter Images

### DIFF
--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -24,7 +24,7 @@ function useIntersectionObserver(ref) {
 
 export default function Person({ person, currentTag }) {
   const url = new URL(person.url);
-  const twitter = `https://unavatar.now.sh/twitter/${person.twitter}`;
+  const twitter = `https://unavatar.now.sh/twitter/${person.twitter.replace('@', '')}`;
   const website = `https://unavatar.now.sh/${url.host}`;
   const unavatar = person.twitter ? `${twitter}?fallback=${website}` : website;
   const img = `https://images.weserv.nl/?url=${unavatar}&w=100&l=9&af&il&n=-1`;


### PR DESCRIPTION
Currently, it looks like https://unavatar.vercel.app/ used to display the Twitter avatars is not working properly with the @ symbol in the URL. For example:
### Works: 
- https://images.weserv.nl/?url=https://unavatar.now.sh/twitter/tim_leland
-  https://images.weserv.nl/?url=https://unavatar.now.sh/twitter/wesbos

### Broken:
- https://images.weserv.nl/?url=https://unavatar.now.sh/twitter/@tim_leland
-  https://images.weserv.nl/?url=https://unavatar.now.sh/twitter/@wesbos