### PR TITLE
📦 NEW: add link check action

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,15 @@
+name: Link-check
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # every monday
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run linksafe
+        uses: TechWiz-3/linksafe@fast
+        env:
+          TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,5 +13,6 @@ jobs:
         uses: TechWiz-3/linksafe@fast
         with:
           whitelist_files: "./package-lock.json"
+          whitelist_links: "https://achhunna.com/uses,https://www.sudhanshubajaj.com/uses/,https://renanmf.com/uses,https://fabianvallejos.com/uses/,https://daochau.com/uses/,https://grailbox.com/uses/,https://chriswiegman.com/uses,https://dev.to/fullstack_to/tools-services-i-use-je9,https://andela.com/,https://www.albertofortes.com/uses"
         env:
           TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -11,5 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run linksafe
         uses: TechWiz-3/linksafe@fast
+        with:
+          whitelist_files: "./package-lock.json"
         env:
           TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
In this PR, I have added a workflow which checks links and fails if any of them are broken.

Disclaimer: this action is my own, the repo is [here](https://github.com/TechWiz-3/linksafe/tree/fast).

Because of the large volume of links, I'm using the 'fast' version/branch which simply requires a GitHub token (with no extra perms) to be stored as a repo secret under the name  `TOKEN`. This is for requests to the GitHub API to avoid rate-limits. More setup info [here](https://github.com/TechWiz-3/linksafe/tree/fast#setup)

You can view the logs of the workflow on my fork [here](https://github.com/TechWiz-3/awesome-uses/actions/runs/3165357794/jobs/5154323420). **51** links were found to be broken.

Let me know if you'd like me to change anything, any feedback is appreciated either way :)

<img width="378" alt="Screen Shot 2022-10-02 at 3 28 09 pm" src="https://user-images.githubusercontent.com/75515581/193437895-7cb10bd4-ff2a-4673-9be5-2253f79aba8d.png">