### PR TITLE
Reduce data usage by sorting and filtering on the frontend

### DIFF
--- a/src/components/Topics.js
+++ b/src/components/Topics.js
@@ -1,19 +1,18 @@
-import { Link, useParams, useRouteLoaderData } from '@remix-run/react';
+import { Link, useParams, useRouteLoaderData, useSearchParams } from '@remix-run/react';
 import * as icons from '../util/icons';
 
 export default function Topics() {
   const { tags, countries, devices } = useRouteLoaderData("root");
-  const params = useParams();
-  const currentTag = params.tag || 'all';
+  const [searchParams] = useSearchParams();
+  const currentTag = searchParams.get('like') || 'all';
 
   return (
     <div className="Tags">
       {tags.map((tag) => (
         <Link
-          prefetch="intent"
           key={`tag-${tag.name}`}
           to={
-            tag.name === "all" ? "/" : `/like/${encodeURIComponent(tag.name)}`
+            tag.name === "all" ? "/" : `?${new URLSearchParams({ like: tag.name }).toString()}`
           }
           className={`Tag ${currentTag === tag.name ? "currentTag" : ""}`}
         >
@@ -24,7 +23,7 @@ export default function Topics() {
 
       {countries.map((tag) => (
         <Link
-          to={`/like/${tag.emoji}`}
+          to={`?${new URLSearchParams({ like: tag.emoji }).toString()}`}
           prefetch="intent"
           className={`Tag ${currentTag === tag.emoji ? "currentTag" : ""}`}
           key={`filter-${tag.name}`}
@@ -37,7 +36,7 @@ export default function Topics() {
 
       {devices.map((tag) => (
         <Link
-          to={`/like/${tag.name}`}
+          to={`?${new URLSearchParams({ like: tag.name }).toString()}`}
           className={`Tag ${currentTag === tag.name ? "currentTag" : ""}`}
           prefetch="intent"
           key={`filter-${tag.name}`}

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -1,4 +1,5 @@
 import type { LinksFunction, MetaFunction } from '@remix-run/node';
+import type { ShouldRevalidateFunction } from '@remix-run/react';
 import {
   Links,
   LiveReload,
@@ -22,6 +23,10 @@ export function loader() {
     devices: devices(),
   }
 }
+
+export const shouldRevalidate: ShouldRevalidateFunction = ({ currentUrl, nextUrl }) => {
+  return Boolean(currentUrl.pathname !== nextUrl.pathname);
+};
 
 const metaData = {
   description: `A list of /uses pages detailing developer setups.`,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,23 +1,41 @@
-import { useLoaderData, useParams } from '@remix-run/react';
-import { json, LoaderArgs } from '@remix-run/server-runtime';
-import React, { useContext } from 'react';
+import { ShouldRevalidateFunction, useLoaderData, useSearchParams } from '@remix-run/react';
 import Topics from '../components/Topics';
 import BackToTop from '../components/BackToTop';
 import Person from '../components/Person';
 import { getPeople } from 'src/util/stats';
 
-export async function loader({ params }: LoaderArgs) {
-  const people = getPeople(params.tag);
-  return {people};
+export async function loader() {
+  const people = getPeople();
+  return { people };
 }
 
+export const shouldRevalidate: ShouldRevalidateFunction = ({ currentUrl, nextUrl }) => {
+  return Boolean(currentUrl.pathname !== nextUrl.pathname);
+};
+
 export default function Index() {
-  const { people } = useLoaderData();
+  const { people } = useLoaderData<typeof loader>();
+  const [searchParams] = useSearchParams();
+  const tag = searchParams.get('like');
+  const filteredPeople = people
+    .filter((person) => {
+      if (!tag) {
+        return true;
+      }
+      return (
+        person.tags.includes(tag) ||
+        person.country === tag ||
+        person.phone === tag ||
+        person.computer === tag
+      );
+    })
+    .sort(() => Math.random() - 0.5);
+
   return (
     <>
       <Topics />
       <div className="People">
-        {people.map(person => (
+        {filteredPeople.map((person) => (
           <Person key={person.name} person={person} />
         ))}
       </div>

--- a/src/routes/like/$tag.tsx
+++ b/src/routes/like/$tag.tsx
@@ -1,1 +1,7 @@
-export { default, loader } from '../index';
+import { LoaderArgs, redirect } from "@remix-run/server-runtime"
+
+export const loader = async ({ params }: LoaderArgs) => {
+    if (!params.tag) return redirect("/")
+
+    return redirect(`/?${new URLSearchParams({ like: params.tag }).toString()}`)
+}

--- a/src/util/stats.ts
+++ b/src/util/stats.ts
@@ -117,9 +117,8 @@ const normalizedTagMap = tags().reduce((acc, tag) => {
   return acc;
 }, {});
 
-export function getPeople(tag?: string) {
+export function getPeople() {
   return [...people]
-    .sort(() => Math.random() - 0.5)
     .map((person) => {
       const normalizedPerson = {
         ...person,
@@ -133,11 +132,4 @@ export function getPeople(tag?: string) {
         id: `person-${normalizedPerson.name}`,
       };
     })
-    .filter((person) => {
-      if (!tag) {
-        return true;
-      }
-      return person.tags.includes(tag) || person.country === tag || person.phone === tag || person.computer === tag;
-    })
-
 }


### PR DESCRIPTION
### Problem

Data for people is being refetched every time a user hovers over or click on a tag. That's usually after all data has been loaded when the user lands on the homepage for the first time.


### Solution

Sort and filter the fetched people on the frontend after fetching the data one.

This reduces data usage and provides faster page transitions.