### PR TITLE
Add support for bluesky urls with one test case

### DIFF
--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -96,7 +96,8 @@ export default function Person({ person }) {
         {/* If they have a mastodon, and no twitter, show that */}
         {person.mastodon && !person.twitter && (
           <div className="SocialHandle">
-            <a href={`https://${mastodonServer}/@${mastodonHandle}`}
+            <a
+              href={`https://${mastodonServer}/@${mastodonHandle}`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -85,7 +85,8 @@ export default function Person({ person }) {
             <a
               href={`https://twitter.com/${person.twitter.replace("@", "")}`}
               target="_blank"
-              rel="noopener noreferrer">
+              rel="noopener noreferrer"
+            >
               <span className="at">@</span>
               {person.twitter.replace("@", "")}
             </a>

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -85,8 +85,7 @@ export default function Person({ person }) {
             <a
               href={`https://twitter.com/${person.twitter.replace("@", "")}`}
               target="_blank"
-              rel="noopener noreferrer"
-            >
+              rel="noopener noreferrer">
               <span className="at">@</span>
               {person.twitter.replace("@", "")}
             </a>
@@ -98,7 +97,8 @@ export default function Person({ person }) {
           <div className="SocialHandle">
             <a href={`https://${mastodonServer}/@${mastodonHandle}`}
               target="_blank"
-              rel="noopener noreferrer">
+              rel="noopener noreferrer"
+            >
               <span className="at">@</span>
               {mastodonHandle}
             </a>
@@ -108,9 +108,10 @@ export default function Person({ person }) {
         {/* If they have a bluesky, and no mastodon and no twitter, show that */}
         {person.bluesky && !person.mastodon && !person.twitter && (
           <div className="SocialHandle">
-            <a href={`https://bsky.app/profile/${person.bluesky}`} 
+            <a href={`https://bsky.app/profile/${person.bluesky}`}
               target="_blank"
-              rel="noopener noreferrer">
+              rel="noopener noreferrer"
+            >
               <span className="at">@</span>
               {person.bluesky}
             </a>

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -96,13 +96,23 @@ export default function Person({ person }) {
         {/* If they have a mastodon, and no twitter, show that */}
         {person.mastodon && !person.twitter && (
           <div className="SocialHandle">
-            <a
-              href={`https://${mastodonServer}/@${mastodonHandle}`}
+            <a href={`https://${mastodonServer}/@${mastodonHandle}`} 
               target="_blank"
-              rel="noopener noreferrer"
-            >
+              rel="noopener noreferrer">
               <span className="at">@</span>
               {mastodonHandle}
+            </a>
+          </div>
+        )}
+
+        {/* If they have a bluesky, and no mastodon and no twitter, show that */}
+        {person.bluesky && !person.mastodon && !person.twitter && (
+          <div className="SocialHandle">
+            <a href={`https://bsky.app/profile/${person.bluesky}`} 
+              target="_blank"
+              rel="noopener noreferrer">
+              <span className="at">@</span>
+              {person.bluesky}
             </a>
           </div>
         )}

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -96,7 +96,7 @@ export default function Person({ person }) {
         {/* If they have a mastodon, and no twitter, show that */}
         {person.mastodon && !person.twitter && (
           <div className="SocialHandle">
-            <a href={`https://${mastodonServer}/@${mastodonHandle}`} 
+            <a href={`https://${mastodonServer}/@${mastodonHandle}`}
               target="_blank"
               rel="noopener noreferrer">
               <span className="at">@</span>

--- a/src/data.js
+++ b/src/data.js
@@ -8,6 +8,7 @@
  * @property {string} country - flag emoji for contributor's country
  * @property {string} [twitter] - optional Twitter username (beginning with `@`)
  * @property {string} [mastodon] - optional Mastodon username & server (beginning with `@`, ex: `@hello@mastodon.social`)
+ * @property {string} [bluesky] - optional Bluesky (bsky.app) handle (do not use `@`)
  * @property {string} [emoji] - some emoji corresponding to the contributor
  * @property {'apple' | 'windows' | 'linux' | 'bsd'} [computer]
  * @property {'iphone' | 'android' | 'windowsphone' | 'flipphone'} [phone]
@@ -3844,7 +3845,7 @@ module.exports = [
     name: 'Salma Alam-Naylor',
     description: 'I write code for your entertainment.',
     url: 'https://whitep4nth3r.com/uses',
-    twitter: '@whitep4nth3r',
+    bluesky: 'whitep4nth3r.com',
     emoji: '⚡️',
     country: '🇬🇧',
     computer: 'apple',


### PR DESCRIPTION
Hello! 

I've added support for Bluesky URLs in profile data.

To avoid complications, I've made it so that if you don't have Twitter,  you don't have Mastodon, but you do have Bluesky, we show that link (which is in line with how the logic was written previously in comparing Twitter and Mastodon).

![image](https://github.com/user-attachments/assets/771f88f9-74a1-4d0f-8b2f-0c467cdb5bde)
