### PR TITLE
Update country property to use flag emoji for Brazil

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -87,7 +87,7 @@ module.exports = [
     url: 'https://iagobruno.is-a.dev/uses',
     twitter: '@iagotico',
     emoji: '🏳️‍🌈',
-    country: 'BR',
+    country: '🇧🇷',
     computer: 'windows',
     phone: 'iphone',
     tags: [


### PR DESCRIPTION
Foi corrigido o uso do 'BR' pelo emoji '🇧🇷' no cadastro do Iago Bruno. Isso fazia com que a listagem de brasileiros estivesse quebrada, mostrando apenas o Iago Bruno sendo que há 19 brasileiros para serem listados.

Below, in English:

The use of 'BR' was corrected to the emoji '🇧🇷' in Iago Bruno's registration. This caused the listing of Brazilians to be broken, showing only Iago Bruno when there are still 19 Brazilians to be listed.