### PR TITLE
Fix duplicate Bluesky links 

### DIFF
--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -90,20 +90,6 @@ export default function Person({ person }) {
           </div>
         )}
 
-        {/* If they have a bluesky, and no twitter/mastodon, show that */}
-        {person.bluesky && !person.twitter && (
-          <div className="SocialHandle">
-            <a
-              href={`https://bsky.app/profile/${person.bluesky.replace("@", "")}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span className="at">@</span>
-              {person.bluesky.substring(1)}
-            </a>
-          </div>
-        )}
-
         {/* If they have a mastodon, and no twitter, show that */}
         {person.mastodon && !person.twitter && !person.bluesky && (
           <div className="SocialHandle">
@@ -121,12 +107,12 @@ export default function Person({ person }) {
         {/* If they have a bluesky, and no mastodon and no twitter, show that */}
         {person.bluesky && !person.mastodon && !person.twitter && (
           <div className="SocialHandle">
-            <a href={`https://bsky.app/profile/${person.bluesky}`}
+            <a href={`https://bsky.app/profile/${person.bluesky.replace("@", "")}`}
               target="_blank"
               rel="noopener noreferrer"
             >
               <span className="at">@</span>
-              {person.bluesky}
+              {person.bluesky.replace("@", "")}
             </a>
           </div>
         )}


### PR DESCRIPTION
If a person has only a Bluesky link, it was displayed twice. It looks like support was added in two independent PRs: #1872, and #1878.

You can see an example of the issue on the single profile displayed here: https://uses.tech/like/Simplicity

I've also tweaked how the handles are normalised. Previously one block removed `@`s in the URL, then blindly chomped off the first character in the display name, while the second assumed there was no `@` prefix. There are a few entries that have an `@`, so I've stuck with just removing it in both places, as that'll work in all current cases.