### PR TITLE
Add Ben Dixon

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -9999,6 +9999,27 @@ module.exports = [
     ],
   },
   {
+    name: 'Ben Dixon',
+    description:
+      'Tests how often AI assistants get things wrong, and publishes the receipts.',
+    url: 'https://dixon.ai/uses/',
+    bluesky: 'dixon.ai',
+    mastodon: '@dixonai@mastodon.social',
+    emoji: '🧾',
+    country: '🇬🇧',
+    computer: 'windows',
+    tags: [
+      'AI',
+      'Astro',
+      'Claude Code',
+      'Cloudflare Pages',
+      'Beehiiv',
+      'PowerShell',
+      'Markdown',
+      'Plain CSS',
+    ],
+  },
+  {
     name: 'Sythe Veenje',
     description: 'Freelance Developer & Designer',
     url: 'https://sythe.nl/uses',


### PR DESCRIPTION
Adding my /uses page: https://dixon.ai/uses/

It's the setup behind dixon.ai, a site that tests how often AI assistants get things wrong and publishes the graded results. Self-built Windows desktop, Astro on Cloudflare Pages, plain CSS, and Claude Code for the build itself.

Entry added mid-array rather than at the end, per the contribution guide. Validated against the schema in `scripts/utils.js` locally.

Thanks for maintaining this — it's a genuinely good corner of the web.