### PR TITLE
fix: send a browser-like User-Agent when validating profile URLs

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -79,8 +79,18 @@ module.exports.getStatusCode = function (url) {
       new Error('Request timed out')
     );
 
+    // Some hosts (Cloudflare, Caddy, etc.) block requests that don't send a
+    // browser-like User-Agent, returning a 403 even though the page is live.
+    // Send one so we don't produce false-positive failures for those sites.
+    const requestOptions = {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; awesome-uses-link-checker/1.0; +https://github.com/wesbos/awesome-uses)',
+      },
+    };
+
     client
-      .get(url, (res) => {
+      .get(url, requestOptions, (res) => {
         clearTimeout(timeoutId);
         resolve(res.statusCode);
       })


### PR DESCRIPTION
## What
The link-check step in `data-validate.yml` (`scripts/utils.js` → `getStatusCode`) pings each contributor's profile URL with a bare `https.get()` / `http.get()`, which sends **no `User-Agent` header at all**.

## Why
Some hosts (Cloudflare, Caddy bot-protection rules, other WAFs) return `403 Forbidden` for requests that don't send a browser-like `User-Agent`, even though the page itself is perfectly reachable from a browser. That produces a false-positive CI failure on the `build` check, blocking otherwise-valid PRs.

Concrete repro from #2194:
```
$ curl -s -o /dev/null -w "%{http_code}\n" https://m1es.net/uses
403
$ curl -s -o /dev/null -w "%{http_code}\n" -A "Mozilla/5.0 ..." https://m1es.net/uses
301
```
Same result reproduced with a plain Node `https.get()` call mirroring the CI script exactly.

## Fix
Send a descriptive, browser-like `User-Agent` header on the outgoing request in `getStatusCode`. This is a one-line, low-risk change that only affects the outgoing request headers — no behavior change for sites that don't gate on User-Agent.

Verified the new header clears the block for the URL from #2194:
```
$ curl -s -o /dev/null -w "%{http_code}\n" -A "Mozilla/5.0 (compatible; awesome-uses-link-checker/1.0; +https://github.com/wesbos/awesome-uses)" https://m1es.net/uses
301
```

## End-to-end verification (real CI run, not just curl)
To confirm this isn't just a local curl approximation, I combined this fix with #2194's actual data change on a branch in my fork and let the real `data-validate.yml` workflow run against it on GitHub's own Actions runners:

➡️ **[Validate data.js — success](https://github.com/m1es/awesome-uses/actions/runs/34161381686)**

The `Validate data.js` step — the exact one that failed with `Ping to "https://m1es.net/uses" failed with status: 403` on #2194 — passes with this fix applied.

Fixes the CI failure blocking #2194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
